### PR TITLE
fix: Fixed ProgressBar bar color not showing up

### DIFF
--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -40,6 +40,6 @@ const ProgressBar: FCCWD<ProgressBarProps> = ({ theme, progress = 0, barColor, p
 export default applyDefaults(ProgressBar);
 
 export const Style = StyleSheet.create({
-  container: { flex: 1, backgroundColor: 'transparent', height: 2, width: '100%', overflow: 'visible', justifyContent: 'center' },
+  container: { backgroundColor: 'transparent', height: 2, width: '100%', overflow: 'visible', justifyContent: 'center' },
   progressStyle: { borderRadius: 14, position: 'absolute', height: 4 },
 });


### PR DESCRIPTION
Deleted 'flex:1' from container style
fix: #5 