### PR TITLE
fix: multiple dropdown onselect prop return type updated

### DIFF
--- a/src/components/Dropdown/MultipleSelectDropdown.tsx
+++ b/src/components/Dropdown/MultipleSelectDropdown.tsx
@@ -56,6 +56,7 @@ const MultipleDropdown: FCCWD<DrowdownProps> = (
     } else {
       selectedObjectsTemp.push(value);
     }
+    onSelect(selectedObjectsTemp);
     setSelectedObjects(selectedObjectsTemp);
   };
 
@@ -147,7 +148,6 @@ const MultipleDropdown: FCCWD<DrowdownProps> = (
                   onPress={() => {
                     setSelectedObjects(item);
                     toggleCheckBox(item);
-                    onSelect({ ...selectedObjects, item });
                   }}
                   style={[
                     Style.row, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,7 +145,7 @@ export type DrowdownProps = {
     containerStyle?: StyleProp<ViewStyle>
     buttonTitle?: string,
     rowStyle?: StyleProp<ViewStyle>
-    onSelect: (item: Array<string> | Array<object> | object) => void,
+    onSelect: (item: Array<string> | Array<object> | object | string) => void,
     defaultValue?: Array<object | string>,
     rowTextStyle?: StyleProp<TextStyle>,
     buttonTextStyle?: StyleProp<TextStyle>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,7 +145,7 @@ export type DrowdownProps = {
     containerStyle?: StyleProp<ViewStyle>
     buttonTitle?: string,
     rowStyle?: StyleProp<ViewStyle>
-    onSelect: (item: Array<string> | Array<object>) => void,
+    onSelect: (item: Array<string> | Array<object> | object) => void,
     defaultValue?: Array<object | string>,
     rowTextStyle?: StyleProp<TextStyle>,
     buttonTextStyle?: StyleProp<TextStyle>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,7 +145,7 @@ export type DrowdownProps = {
     containerStyle?: StyleProp<ViewStyle>
     buttonTitle?: string,
     rowStyle?: StyleProp<ViewStyle>
-    onSelect: (item: string | object) => void,
+    onSelect: (item: Array<string> | Array<object>) => void,
     defaultValue?: Array<object | string>,
     rowTextStyle?: StyleProp<TextStyle>,
     buttonTextStyle?: StyleProp<TextStyle>,


### PR DESCRIPTION
Multiple dropdown menu onselect prop return type updated.  Now returns an array object, not an object.

fix: #16 

### Test Plan

Make sure that the onselect prop now returns an array object when the property is changed.