### PR TITLE
fix: TextInput disabled prop removed

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -273,7 +273,6 @@ export type TextInputProps = {
     size?: 'large' | 'medium' | 'small',
     iconPosition?: 'left' | 'right',
     labelColor?: { focus: string, default: string },
-    disabled?: boolean,
     helperText?: string,
     helperTextStyle?: StyleProp<TextStyle>,
     variant?: 'filled' | 'outlined',


### PR DESCRIPTION
fix: #27 

React native TextInput component does not have disabled prop. We have removed this prop. You can use the editable prop.