### PR TITLE
fix: react-native-pager-view installation added to documentation

### DIFF
--- a/doc/docs/doc/getting-started.md
+++ b/doc/docs/doc/getting-started.md
@@ -113,7 +113,6 @@ npm install react-native-pager-view
 
 **react-native-reanimated**
 
-
 ```bash npm2yarn
 npx expo install react-native-reanimated
 ```
@@ -138,6 +137,16 @@ Add this import to the top of your app entry file, such as App.js:
 
 ```js
 import 'react-native-gesture-handler';
+```
+**react-native-pager-view**
+
+```bash npm2yarn
+npx expo install react-native-pager-view
+```
+Add this import to the top of your app entry file, such as App.js:
+
+```js
+import 'react-native-pager-view';
 ```
 </TabItem>
 </Tabs>

--- a/doc/docs/doc/getting-started.md
+++ b/doc/docs/doc/getting-started.md
@@ -143,11 +143,7 @@ import 'react-native-gesture-handler';
 ```bash npm2yarn
 npx expo install react-native-pager-view
 ```
-Add this import to the top of your app entry file, such as App.js:
 
-```js
-import 'react-native-pager-view';
-```
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Since the react-native-pager-view package needs to be installed when using the pager view component, installation has been added to the document.