### PR TITLE
fix: Activity indicator now aligns to the center of the screen

### DIFF
--- a/src/components/ActivityIndicator/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator/ActivityIndicator.tsx
@@ -16,6 +16,8 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     width: 150,
     height: 150,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 const ActivityIndicator:FCCWD<ActivityIndicatorProps> = ({ theme, children }) => (

--- a/src/components/__tests__/__snapshots__/activity-indicator.test.js.snap
+++ b/src/components/__tests__/__snapshots__/activity-indicator.test.js.snap
@@ -29,8 +29,10 @@ exports[`ActiviyIndicator renders avtivity indicator 1`] = `
       style={
         [
           {
+            "alignItems": "center",
             "borderRadius": 20,
             "height": 150,
+            "justifyContent": "center",
             "width": 150,
           },
         ]
@@ -177,8 +179,10 @@ exports[`ActiviyIndicator renders avtivity indicator with children 1`] = `
       style={
         [
           {
+            "alignItems": "center",
             "borderRadius": 20,
             "height": 150,
+            "justifyContent": "center",
             "width": 150,
           },
         ]


### PR DESCRIPTION
Activity indicator was not aligned in the center of the screen. After this pull request this issue will disappear.